### PR TITLE
Fix: guard NewModule against duplicate registration

### DIFF
--- a/Data/BattleforAzeroth-Retail.lua
+++ b/Data/BattleforAzeroth-Retail.lua
@@ -30,7 +30,7 @@ local BZ                   = Atlas_GetLocaleLibBabble("LibBabble-SubZone-3.0")
 local L                    = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC                  = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas                = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local BfA                  = Atlas:NewModule(private.module_name)
+local BfA                  = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db                   = {}
 BfA.db                     = db

--- a/Data/BurningCrusade-Classic.lua
+++ b/Data/BurningCrusade-Classic.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	local BB = Atlas_GetLocaleLibBabble("LibBabble-Boss-3.0")

--- a/Data/BurningCrusade-ClassicEraTBC.lua
+++ b/Data/BurningCrusade-ClassicEraTBC.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	local BB = Atlas_GetLocaleLibBabble("LibBabble-Boss-3.0")

--- a/Data/BurningCrusade-ClassicEraWOTLK.lua
+++ b/Data/BurningCrusade-ClassicEraWOTLK.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	local BB = Atlas_GetLocaleLibBabble("LibBabble-Boss-3.0")

--- a/Data/BurningCrusade-Retail.lua
+++ b/Data/BurningCrusade-Retail.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	return Atlas:GetBossName(bossname, encounterID, creatureIndex, private.module_name)

--- a/Data/Cataclysm-Classic.lua
+++ b/Data/Cataclysm-Classic.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local Cata = Atlas:NewModule(private.module_name)
+local Cata = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 Cata.db = db

--- a/Data/Cataclysm-Retail.lua
+++ b/Data/Cataclysm-Retail.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local Cata = Atlas:NewModule(private.module_name)
+local Cata = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 Cata.db = db

--- a/Data/Classic-Classic.lua
+++ b/Data/Classic-Classic.lua
@@ -31,7 +31,7 @@ local BF                   = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L                    = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC                  = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas                = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon                = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	return Atlas:GetBossName(bossname, encounterID, creatureIndex, private.module_name)

--- a/Data/Classic-ClassicEra.lua
+++ b/Data/Classic-ClassicEra.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local isSoD = false;
 if (C_Seasons.GetActiveSeason() == 2) then

--- a/Data/Classic-Retail.lua
+++ b/Data/Classic-Retail.lua
@@ -31,7 +31,7 @@ local BF                   = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L                    = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC                  = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas                = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local addon                = Atlas:NewModule(private.module_name)
+local addon = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local function Atlas_GetBossName(bossname, encounterID, creatureIndex)
 	return Atlas:GetBossName(bossname, encounterID, creatureIndex, private.module_name)

--- a/Data/Dragonflight-Retail.lua
+++ b/Data/Dragonflight-Retail.lua
@@ -29,7 +29,7 @@ private.module_name = "Dragonflight"
 local BZ = Atlas_GetLocaleLibBabble("LibBabble-SubZone-3.0")
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local DF = Atlas:NewModule(private.module_name)
+local DF = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 DF.db = db

--- a/Data/Legion-Retail.lua
+++ b/Data/Legion-Retail.lua
@@ -30,7 +30,7 @@ local BZ = Atlas_GetLocaleLibBabble("LibBabble-SubZone-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local Legion = Atlas:NewModule(private.module_name)
+local Legion = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 Legion.db = db

--- a/Data/Midnight-Retail.lua
+++ b/Data/Midnight-Retail.lua
@@ -28,7 +28,7 @@ private.module_name = "Midnight"
 
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local Midnight = Atlas:NewModule(private.module_name)
+local Midnight = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 Midnight.db = db

--- a/Data/MistsofPandaria-Classic.lua
+++ b/Data/MistsofPandaria-Classic.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local MoP = Atlas:NewModule(private.module_name)
+local MoP = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 MoP.db = db

--- a/Data/MistsofPandaria-Retail.lua
+++ b/Data/MistsofPandaria-Retail.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local MoP = Atlas:NewModule(private.module_name)
+local MoP = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 MoP.db = db

--- a/Data/Shadowlands-Retail.lua
+++ b/Data/Shadowlands-Retail.lua
@@ -29,7 +29,7 @@ private.module_name = "Shadowlands"
 local BZ = Atlas_GetLocaleLibBabble("LibBabble-SubZone-3.0")
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local SDL = Atlas:NewModule(private.module_name)
+local SDL = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 SDL.db = db

--- a/Data/TheWarWithin-Retail.lua
+++ b/Data/TheWarWithin-Retail.lua
@@ -28,7 +28,7 @@ private.module_name = "TheWarWithin"
 
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local TWW = Atlas:NewModule(private.module_name)
+local TWW = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 TWW.db = db

--- a/Data/WarlordsofDraenor-Retail.lua
+++ b/Data/WarlordsofDraenor-Retail.lua
@@ -30,7 +30,7 @@ local BZ = Atlas_GetLocaleLibBabble("LibBabble-SubZone-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local WoD = Atlas:NewModule(private.module_name)
+local WoD = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 WoD.db = db

--- a/Data/WrathoftheLichKing-Classic.lua
+++ b/Data/WrathoftheLichKing-Classic.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local WoLK = Atlas:NewModule(private.module_name)
+local WoLK = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 WoLK.db = db

--- a/Data/WrathoftheLichKing-Retail.lua
+++ b/Data/WrathoftheLichKing-Retail.lua
@@ -31,7 +31,7 @@ local BF = Atlas_GetLocaleLibBabble("LibBabble-Faction-3.0")
 local L = LibStub("AceLocale-3.0"):GetLocale(private.addon_name)
 local ALC = LibStub("AceLocale-3.0"):GetLocale("Atlas")
 local Atlas = LibStub("AceAddon-3.0"):GetAddon("Atlas")
-local WoLK = Atlas:NewModule(private.module_name)
+local WoLK = Atlas:GetModule(private.module_name, true) or Atlas:NewModule(private.module_name)
 
 local db = {}
 WoLK.db = db


### PR DESCRIPTION
If multiple TOC files (e.g. Atlas.toc and Atlas_Vanilla.toc) are both loaded by the WoW client, each Data/*.lua file is executed twice, causing AceAddon-3.0 to throw 'Module already exists' on the second Atlas:NewModule(private.module_name) call.

Use GetModule(name, true) as a guard so the existing module is reused on subsequent loads instead of erroring.